### PR TITLE
Change images links to reference the just the picture 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ I created this as proof of concept and it certainly needed a bit more refinement
 This connector was designed for creating a 90-degree joint between 1/2" (12.7 mm) to 3/4" (19 mm) stock (plywood, OSB, lumber, etc.). I used a 1-1/4" #8-32 machine screw and nut (it's what I had on hand); you will need a longer nut for 3/4" stock. 
 
 **Side view:**
-![alt text](https://github.com/MaslowCommunityGarden/Edge-Clamp-Connector/blob/master/pictures/IMG_2682.jpg)
+![alt text](https://raw.githubusercontent.com/MaslowCommunityGarden/Edge-Clamp-Connector/master/pictures/IMG_2682.jpg)
 
 **Top view:**
-![alt text](https://github.com/MaslowCommunityGarden/Edge-Clamp-Connector/blob/master/pictures/IMG_2683.jpg)
+![alt text](https://raw.githubusercontent.com/MaslowCommunityGarden/Edge-Clamp-Connector/master/pictures/IMG_2683.jpg)
 
 **Bottom view**
-![alt text](https://github.com/MaslowCommunityGarden/Edge-Clamp-Connector/blob/master/pictures/IMG_2685.jpg)
+![alt text](https://raw.githubusercontent.com/MaslowCommunityGarden/Edge-Clamp-Connector/master/pictures/IMG_2685.jpg)


### PR DESCRIPTION
The pictures in the text weren't showing up for me in the main project page on the website like this:

![image](https://user-images.githubusercontent.com/9359447/38154966-d67cceb4-3429-11e8-99e5-2409bd5e36b3.png)

This is because github lets you use the friendly URL when embedding pictures in files like the README file. In fact in the README you can even reference a picture with a local address like (/pictures/picture1), but to make them show up on the main page they have to be the full address. There's instructions at the bottom of the instructions page here: http://maslowcommunitygarden.org/Website.html 

I'm thinking I might make the robot automatically make pull requests to fix this kind of thing because it's going to come up a lot